### PR TITLE
Payment processor improvements dylan

### DIFF
--- a/RefactorThis.Domain.Tests/InvoicePaymentProcessorTests.cs
+++ b/RefactorThis.Domain.Tests/InvoicePaymentProcessorTests.cs
@@ -38,9 +38,9 @@ namespace RefactorThis.Domain.Tests
 
 			var invoice = new Invoice( repo )
 			{
-				Amount = 0,
+				AmountRemaining = 0,
 				AmountPaid = 0,
-				Payments = null
+				PaymentsMade = null
 			};
 
 			repo.Add( invoice );
@@ -61,9 +61,9 @@ namespace RefactorThis.Domain.Tests
 
 			var invoice = new Invoice( repo )
 			{
-				Amount = 10,
+				AmountRemaining = 10,
 				AmountPaid = 10,
-				Payments = new List<Payment>
+				PaymentsMade = new List<Payment>
 				{
 					new Payment
 					{
@@ -88,9 +88,9 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				Amount = 10,
+				AmountRemaining = 10,
 				AmountPaid = 5,
-				Payments = new List<Payment>
+				PaymentsMade = new List<Payment>
 				{
 					new Payment
 					{
@@ -118,9 +118,9 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				Amount = 5,
+				AmountRemaining = 5,
 				AmountPaid = 0,
-				Payments = new List<Payment>( )
+				PaymentsMade = new List<Payment>( )
 			};
 			repo.Add( invoice );
 
@@ -142,9 +142,10 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				Amount = 10,
+				AmountRemaining = 10,
 				AmountPaid = 5,
-				Payments = new List<Payment>
+				
+				PaymentsMade = new List<Payment>
 				{
 					new Payment
 					{
@@ -172,9 +173,9 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				Amount = 10,
+				AmountRemaining = 10,
 				AmountPaid = 0,
-				Payments = new List<Payment>( ) { new Payment( ) { Amount = 10 } }
+				PaymentsMade = new List<Payment>( ) { new Payment( ) { Amount = 10 } }
 			};
 			repo.Add( invoice );
 
@@ -196,9 +197,9 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				Amount = 10,
+				AmountRemaining = 10,
 				AmountPaid = 5,
-				Payments = new List<Payment>
+				PaymentsMade = new List<Payment>
 				{
 					new Payment
 					{
@@ -226,9 +227,9 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				Amount = 10,
+				AmountRemaining = 10,
 				AmountPaid = 0,
-				Payments = new List<Payment>( )
+				PaymentsMade = new List<Payment>( )
 			};
 			repo.Add( invoice );
 

--- a/RefactorThis.Domain.Tests/InvoicePaymentProcessorTests.cs
+++ b/RefactorThis.Domain.Tests/InvoicePaymentProcessorTests.cs
@@ -38,7 +38,7 @@ namespace RefactorThis.Domain.Tests
 
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 0,
+				TotalAmount = 0,
 				AmountPaid = 0,
 				PaymentsMade = null
 			};
@@ -61,7 +61,7 @@ namespace RefactorThis.Domain.Tests
 
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 10,
+				TotalAmount = 10,
 				AmountPaid = 10,
 				PaymentsMade = new List<Payment>
 				{
@@ -88,7 +88,7 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 10,
+				TotalAmount = 10,
 				AmountPaid = 5,
 				PaymentsMade = new List<Payment>
 				{
@@ -118,7 +118,7 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 5,
+				TotalAmount = 5,
 				AmountPaid = 0,
 				PaymentsMade = new List<Payment>( )
 			};
@@ -142,7 +142,7 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 10,
+				TotalAmount = 10,
 				AmountPaid = 5,
 				
 				PaymentsMade = new List<Payment>
@@ -173,7 +173,7 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 10,
+				TotalAmount = 10,
 				AmountPaid = 0,
 				PaymentsMade = new List<Payment>( ) { new Payment( ) { Amount = 10 } }
 			};
@@ -197,7 +197,7 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 10,
+				TotalAmount = 10,
 				AmountPaid = 5,
 				PaymentsMade = new List<Payment>
 				{
@@ -227,7 +227,7 @@ namespace RefactorThis.Domain.Tests
 			var repo = new InvoiceRepository( );
 			var invoice = new Invoice( repo )
 			{
-				AmountRemaining = 10,
+				TotalAmount = 10,
 				AmountPaid = 0,
 				PaymentsMade = new List<Payment>( )
 			};

--- a/RefactorThis.Domain/InvoicePaymentProcessor.cs
+++ b/RefactorThis.Domain/InvoicePaymentProcessor.cs
@@ -13,84 +13,77 @@ namespace RefactorThis.Domain
 			_invoiceRepository = invoiceRepository;
 		}
 
-		public string ProcessPayment( Payment payment )
+		private void SafetyChecks ( Invoice invoice, Payment payment )
 		{
-			var inv = _invoiceRepository.GetInvoice( payment.Reference );
-
-			var responseMessage = string.Empty;
-
-			if ( inv == null )
+			if ( invoice == null )
 			{
 				throw new InvalidOperationException( "There is no invoice matching this payment" );
 			}
 			
-			
-			if ( inv.TotalAmount < 0 )
+			if ( invoice.TotalAmount < 0 )
 			{
 				throw new InvalidOperationException( "The invoice is in an invalid state, it has an amount less than 0." );
 			}
+
+			if ( payment == null )
+			{
+				throw new InvalidOperationException( "Critical error, payment is null" );
+			}
+			
+			if ( payment.Amount <= 0 )
+			{
+				throw new InvalidOperationException( "Critical error, payment must have a value" );
+			}
+		}
+
+		private string ReceivePayment(Payment payment, Invoice invoice )
+		{
+			var responseMessage = "";
+
+			if (invoice.RemainingBalance() == 0)
+			{
+				return "invoice was already fully paid";
+			}
+			
+			if ( invoice.RemainingBalance() < payment.Amount )
+			{
+				return "the payment is greater than the invoice amount, you owe $" + invoice.RemainingBalance();
+			}
+
+			var remainingAmount = invoice.AddPayment(payment);
+
+			if ( remainingAmount == 0 )
+			{
+				responseMessage = "invoice is now fully paid";
+			}
+			else
+			{
+				responseMessage = "invoice has been paid. There is still $" + remainingAmount + " owing";
+			}
+			
+			return responseMessage;
+		}
+
+		public string ProcessPayment( Payment payment )
+		{
+			var inv = _invoiceRepository.GetInvoice( payment.Reference );
+
+			SafetyChecks(inv, payment);
 			
 			//Check if $0 invoice has received payments.
 			if ( inv.TotalAmount == 0 ) 
 			{
-					if ( inv.PaymentsMade == null || !inv.PaymentsMade.Any( ) )
+					if ( !inv.PaymentsMade.Any( ) )
 					{
-						responseMessage = "no payment needed";
+						return "no payment needed";
 					}
 					else
 					{
 						throw new InvalidOperationException( "The invoice is in an invalid state, it has an amount of 0 and it has payments." );
 					}
 			}
-			else
-			{
-				if ( inv.PaymentsMade != null && inv.PaymentsMade.Any( ) )
-				{
-					if ( inv.RemainingBalance() != 0 && inv.TotalAmount == inv.RemainingBalance() ) 
-					{
-						responseMessage = "invoice was already fully paid";
-					}
-					else if ( inv.PaymentsMade.Sum( x => x.Amount ) != 0 && payment.Amount > ( inv.TotalAmount - inv.AmountPaid ) )
-					{
-						responseMessage = "the payment is greater than the partial amount remaining";
-					}
-					else
-					{
-						if ( ( inv.TotalAmount - inv.AmountPaid ) == payment.Amount )
-						{
-							inv.AmountPaid += payment.Amount;
-							inv.PaymentsMade.Add( payment );
-							responseMessage = "final partial payment received, invoice is now fully paid";
-						}
-						else
-						{
-							inv.AmountPaid += payment.Amount;
-							inv.PaymentsMade.Add( payment );
-							responseMessage = "another partial payment received, still not fully paid";
-						}
-					}
-				}
-				else
-				{
-					if ( payment.Amount > inv.TotalAmount )
-					{
-						responseMessage = "the payment is greater than the invoice amount";
-					}
-					else if ( inv.TotalAmount == payment.Amount )
-					{
-						inv.AmountPaid = payment.Amount;
-						inv.PaymentsMade.Add( payment );
-						responseMessage = "invoice is now fully paid";
-					}
-					else
-					{
-						inv.AmountPaid = payment.Amount;
-						inv.PaymentsMade.Add( payment );
-						responseMessage = "invoice is now partially paid";
-					}
-				}
-			}
-		
+
+			var responseMessage = ReceivePayment(payment, inv);
 			
 			inv.Save();
 

--- a/RefactorThis.Persistence/Invoice.cs
+++ b/RefactorThis.Persistence/Invoice.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,9 +7,11 @@ namespace RefactorThis.Persistence
 	public class Invoice
 	{
 		private readonly InvoiceRepository _repository;
+		
 		public Invoice( InvoiceRepository repository )
 		{
 			_repository = repository;
+			PaymentsMade = new List<Payment>();
 		}
 
 		public void Save( )
@@ -18,12 +21,26 @@ namespace RefactorThis.Persistence
 
 		public decimal TotalAmount { get; set; }
 		public decimal AmountPaid { get; set; }
-		public List<Payment> PaymentsMade { get; set; }
+		public List<Payment> PaymentsMade { get; }
+
+		public decimal AddPayment(Payment payment)
+		{
+			PaymentsMade.Add(payment);
+			AmountPaid += payment.Amount;
+			return RemainingBalance();
+		}
 
 		public decimal RemainingBalance()
 		{
-			var remainingAmount = PaymentsMade.Sum(x => x.Amount);
-			return remainingAmount;
+			var sumRemainingAmount = TotalAmount - PaymentsMade.Sum(x => x.Amount);
+			var minusRemainingAmount = TotalAmount - AmountPaid;
+
+			if (sumRemainingAmount != minusRemainingAmount)
+			{
+				throw new InvalidOperationException( "The PaymentsMade does not match the AmountPaid" );
+			}
+			
+			return sumRemainingAmount;
 		}
 
 	}

--- a/RefactorThis.Persistence/Invoice.cs
+++ b/RefactorThis.Persistence/Invoice.cs
@@ -15,8 +15,9 @@ namespace RefactorThis.Persistence
 			_repository.SaveInvoice( this );
 		}
 
-		public decimal Amount { get; set; }
+		public decimal AmountRemaining { get; set; }
 		public decimal AmountPaid { get; set; }
-		public List<Payment> Payments { get; set; }
+		public List<Payment> PaymentsMade { get; set; }
+
 	}
 }

--- a/RefactorThis.Persistence/Invoice.cs
+++ b/RefactorThis.Persistence/Invoice.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace RefactorThis.Persistence
 {
@@ -15,9 +16,15 @@ namespace RefactorThis.Persistence
 			_repository.SaveInvoice( this );
 		}
 
-		public decimal AmountRemaining { get; set; }
+		public decimal TotalAmount { get; set; }
 		public decimal AmountPaid { get; set; }
 		public List<Payment> PaymentsMade { get; set; }
+
+		public decimal RemainingBalance()
+		{
+			var remainingAmount = PaymentsMade.Sum(x => x.Amount);
+			return remainingAmount;
+		}
 
 	}
 }


### PR DESCRIPTION
 Refactored Invoice, InvoicePaymentProcessor, InvoicePaymentProcessorTests

Invoice
- added AddPayment method which updates the fields of the invoice object (moved that dependency)
- made PaymentsMade List initialise in the constructor, removing need for null checks AND .Any() calls
- Removed the ability to set PaymentsMade, the only way you should be able to set payments in through the AddPayment method
- Added checks to RemainingBalance() method to double check the sum of payments made matches the AmountPaid

InvoicePaymentProcessorTests
- Fixed spelling error
- Removed invalid payments
- Made it so all invoices start with 0 AmountPaid and add payments, as invoices should  record all payments and should not start with a balance.
- Added test to detect invalid payment
- Changed messages being returned. Justification: From a customer perspective, I personally do not care if I made a payment previously, I just want to know if the payment was received and how much I have owing. Having details of various scenarios about if partial payment or not seems unnecessary. However if you do not want to mention the amount due to privacy concerns I completely understand.

InvoicePaymentProcessor
- Extracted the safety checks to a separate method, will be easier to debug and add new case if they were to arise.
- Added ReceivePayment method where most of the logic has been moved to, also used for determining the responseMessage.
- Greatly reduced the ProcessPayment method and added a comment to make a necessary condition easier to understand at a glance

I would usually have release notes here but I thought my final commit gave a description and justification for what I've changed